### PR TITLE
Add html2js preprocessor to create the templates

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,6 +31,7 @@ module.exports = function(config) {
       'tests/js/helper.js',
       'src/app.js',
       'src/**/*.js',
+      '**/*.html',
       'tests/js/**/*Spec.js'
     ],
 
@@ -42,6 +43,11 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+       'templates/**/*.html': ['ng-html2js']
+    },
+
+    ngHtml2JsPreprocessor: {
+      moduleName: 'spendb.templates'
     },
 
     // test results reporter to use

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "karma": "^0.12.36",
     "karma-chai": "0.1.0",
     "karma-mocha": "^0.1.10",
+    "karma-ng-html2js-preprocessor": "^0.2.0",
     "karma-phantomjs-launcher": "0.1.4",
     "karma-sinon-chai": "0.3.0",
     "mocha": "^2.2.5"


### PR DESCRIPTION
## What does this PR do?

Makes the test pass again.
The templates html files will be created as spenddb.templates module for angular to use. This is needed for the tests to run.

fixes #1 
